### PR TITLE
Use development@adadev.org email everywhere

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -153,7 +153,7 @@ title: Donate to Ada Loan Fund
     Contact Name: Abigail Bielemeier, Controller<br>
     Phone Number: +1 (888) 231-2170 ext. 138</p>
     <h3>What if I didn't receive a receipt?</h3>
-    <p>PayPal will issue you a receipt acknowledging your donation. If you do not receive a receipt or require additional documentation or special acknowledgement, please email Ada Development at development@adadevelopersacademy.org.</p>
+    <p>PayPal will issue you a receipt acknowledging your donation. If you do not receive a receipt or require additional documentation or special acknowledgement, please email Ada Development at <a href="mailto:development@adadev.org?subject=Did%20not%20receive%20receipt">development@adadev.org</a>.</p>
     <p>If your employer does donation matching, please send your receipt to them and provide the method of donation listed above so that they can make a matching gift.</p>
   </div>
 </div>
@@ -162,7 +162,7 @@ title: Donate to Ada Loan Fund
     <div class="address">
       <h3>Ada Developers Academy</h3>
       <p>1215 4th Ave, Ste 1050, Seattle, Washington 98161</p>
-      <p><a href="mailto:donate@adadevelopersacademy.org">donate@adadevelopersacademy.org</a></p>
+      <p><a href="mailto:development@adadev.org">development@adadev.org</a></p>
     </div>
   </div>
   <div class="footer--copyright">


### PR DESCRIPTION
We were still using the donate email address in the footer. Also
switched to using adadev.org domain and made the email address in the
FAQ answer into a mailto link.